### PR TITLE
Tweaks and more LoopVectorization support

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -12,7 +12,7 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 julia = "1"
 LoopVectorization = "0.12.3"
 TropicalNumbers = "0.2"
-VectorizationBase = "0.19.10"
+VectorizationBase = "0.19.11"
 
 [extras]
 Octavian = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"

--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,9 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 
 [compat]
 julia = "1"
-LoopVectorization = "0.12"
+LoopVectorization = "0.12.3"
 TropicalNumbers = "0.2"
-VectorizationBase = "0.19"
+VectorizationBase = "0.19.10"
 
 [extras]
 Octavian = "6fd5a793-0b7e-452c-907f-f8bfe9c57db4"

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -7,6 +7,8 @@ using VectorizationBase: contiguous_batch_size, contiguous_axis, val_stride_rank
 LoopVectorization.check_args(::Type{T}, ::Type{T}) where T<:Tropical = true
 LoopVectorization.check_type(::Type{Tropical{T}}) where {T} = LoopVectorization.check_type(T)
 
+@inline Base.FastMath.add_fast(a::Tropical, b::Tropical) = Tropical(Base.FastMath.max_fast(content(a), content(b)))
+
 @inline function VectorizationBase._vstore!(
     ptr::AbstractStridedPointer, vu::Tropical{<:VecUnroll{Nm1,W}}, u::Unroll{AU,F,N,AV,W}, a::A, s::S, nt::NT, si::StaticInt{RS}
 ) where {A<:StaticBool,S<:StaticBool,NT<:StaticBool,RS,AU,F,N,AV,W,Nm1}
@@ -54,26 +56,29 @@ end
     VectorizationBase.OffsetPrecalc(notropical(ptr.ptr), ptr.precalc)
 end
 
-@inline function VectorizationBase._vload(ptr::AbstractStridedPointer{Tropical{T}}, u::Unroll, a::A, si::StaticInt{RS}) where {T,A<:StaticBool,RS}
-    res = VectorizationBase._vload(notropical(ptr), u, a, si)
+@inline function VectorizationBase._vload(ptr::AbstractStridedPointer{Tropical{T}}, u::Unroll, ::A, ::StaticInt{RS}) where {T,A<:StaticBool,RS}
+    res = VectorizationBase._vload(notropical(ptr), u, A(), StaticInt{RS}())
     Tropical(res)
 end
 
-@inline function VectorizationBase.zero_vecunroll(n::StaticInt{N}, w::StaticInt{W}, ::Type{Tropical{T}}, si::StaticInt{RS}) where {N,W,T,RS}
-    res = Tropical(VectorizationBase.zero_vecunroll(n, w, T, si))
-    return res
+@generated function VectorizationBase.zero_vecunroll(::StaticInt{N}, ::StaticInt{W}, ::Type{Tropical{T}}, ::StaticInt{RS}) where {N,W,T,RS}
+    quote
+        $(Expr(:meta,:inline))
+        t = Base.Cartesian.@ntuple $N n -> VectorizationBase._vbroadcast(StaticInt{$W}(), $(T(-Inf)), StaticInt{$RS}())
+        Tropical(VecUnroll(t))
+    end
 end
 
 @inline function Base.promote_rule(::Type{Tropical{T1}}, ::Type{Tropical{T2}}) where {T1<:VecUnroll,T2<:Vec}
     Tropical{promote_rule(T1, T2)}
 end
 
-@inline function VectorizationBase._vzero(::StaticInt{W}, ::Type{T}, ::StaticInt{RS}) where {W,T<:Tropical{FT},RS} where FT
+@inline function VectorizationBase._vzero(::StaticInt{W}, ::Type{T}, ::StaticInt{RS}) where {W,FT,T<:Tropical{FT},RS}
     Tropical(VectorizationBase._vbroadcast(StaticInt{W}(), FT(-Inf), StaticInt{RS}()))
 end
 
 @inline function VectorizationBase.fma(x::Tropical{V}, y::Tropical{V}, z::Tropical{V}) where {V<:VectorizationBase.AbstractSIMD}
-    Tropical(max(content(z), content(x) + content(y)))
+    Tropical(Base.FastMath.max_fast(content(z), Base.FastMath.add_fast(content(x), content(y))))
 end
 
 # is `gep` a shorthand for "get element pointer"?
@@ -102,5 +107,21 @@ end
 
 # julia 1.5 patch
 @inline function VectorizationBase.VecUnroll(data::Tuple{T,Vararg{T,N}}) where {N,T<:Tropical}
-    Tropical.(VecUnroll(content.(data)))
+    Tropical(VecUnroll(map(content, data)))
 end
+
+@inline LoopVectorization.vecmemaybe(x::Tropical) = x
+@inline function VectorizationBase.collapse_add(vu::Tropical{VecUnroll{N,W,T,V}}) where {N,W,T,V}
+    Tropical(VectorizationBase.collapse_max(content(vu)))
+end
+@inline function VectorizationBase.contract_add(vu::Tropical{VecUnroll{N,W,T,V}}, ::StaticInt{K}) where {N,W,T,V,K}
+    Tropical(VectorizationBase.contract_max(content(vu), StaticInt{K}()))
+end
+@inline function VectorizationBase.reduced_add(x::Tropical, y::Tropical)
+    Tropical(VectorizationBase.reduced_max(content(x), content(y)))
+end
+
+@inline function VectorizationBase.ifelse(f::F, m::AbstractMask, v1::Tropical, v2::Tropical, v3::Tropical) where {F}
+    Tropical(VectorizationBase.ifelse(m, content(f(v1, v2, v3)), content(v3)))
+end
+

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -77,8 +77,11 @@ end
     Tropical(VectorizationBase._vbroadcast(StaticInt{W}(), FT(-Inf), StaticInt{RS}()))
 end
 
-@inline function VectorizationBase.fma(x::Tropical{V}, y::Tropical{V}, z::Tropical{V}) where {V<:VectorizationBase.AbstractSIMD}
+@inline function Base.fma(x::Tropical{V}, y::Tropical{V}, z::Tropical{V}) where {V<:VectorizationBase.AbstractSIMD}
     Tropical(Base.FastMath.max_fast(content(z), Base.FastMath.add_fast(content(x), content(y))))
+end
+@inline function Base.fma(::StaticInt{N}, y::Tropical{V}, z::Tropical{V}) where {N,V<:VectorizationBase.AbstractSIMD}
+    Base.FastMath.add_fast(Base.FastMath.mul_fast(StaticInt{N}(), y), z)
 end
 
 # `gep` is a shorthand for "get element pointer"


### PR DESCRIPTION
Also some fixes, like `zero_vecunroll` should return a bunch of `Vec`s of `-Inf`.

I also really don't like those promote definitions.
When where they needed? Do you have an example?
I suspect they aren't, but didn't want to touch them without some test case I could use to confirm.

I am also use `Base.FastMath.max_fast` instead of `max`, as this cuts out a few instructions. It didn't have much of an impact on performance, but it cleans up the assembly nicely.

Benchmarks on my computer:
```julia
julia> A = randn(1000,1000);

julia> B = randn(1000,1000);

julia> Cref = A*B; C = similar(Cref);

julia> At = Tropical.(A);

julia> Bt = Tropical.(B);

julia> Ctref = At * Bt; Ct = similar(Ctref);

julia> @benchmark Octavian.matmul_serial!($C,$A,$B)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     17.310 ms (0.00% GC)
  median time:      17.409 ms (0.00% GC)
  mean time:        17.409 ms (0.00% GC)
  maximum time:     18.099 ms (0.00% GC)
  --------------
  samples:          288
  evals/sample:     1

julia> 2e-9*1000^3 / 17.31e-3
115.54015020219526

julia> C ≈ Cref
true

julia> @benchmark Octavian.matmul_serial!($Ct,$At,$Bt)
BenchmarkTools.Trial:
  memory estimate:  0 bytes
  allocs estimate:  0
  --------------
  minimum time:     31.906 ms (0.00% GC)
  median time:      31.946 ms (0.00% GC)
  mean time:        31.960 ms (0.00% GC)
  maximum time:     32.764 ms (0.00% GC)
  --------------
  samples:          157
  evals/sample:     1

julia> 2e-9*1000^3 / 31.906e-3
62.684134645521226

julia> Ct ≈ Ctref
true

julia> 4.1 * 2 * 16 # peak theoretical `Float64` gflops
131.2

julia> 4.1 * 2 * 8 # peak theoretical `Tropical{Float64}` gflops
65.6
```
We get `62.7` out of the theoretical peak of `65.6` gflops on my machine.
I think that's pretty good; very little performance left on the table.

Peak GFLOPS is calculated as clock speed * instructions/clock * ops/instruction.
`Float64` has twice the theoretical peak thanks to fused multiply add instructions, i.e. 16 `Float64` operations per fma with AVX512, while for `Tropical{Float64}` it has 8 operations per `max` and per `+`.