### PR TITLE
upgrade dependencies

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -10,7 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.6'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TropicalGEMM"
 uuid = "a4ad3063-64a7-4bad-8738-34ed09bc0236"
 authors = ["GiggleLiu <cacate0129@gmail.com> and contributors"]
-version = "0.1.1"
+version = "0.1.2"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -15,7 +15,7 @@ LoopVectorization = "0.12.4"
 Octavian = "0.2"
 TropicalNumbers = "0.2.3"
 VectorizationBase = "0.20"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 LoopVectorization = "0.12.4"
 Octavian = "0.2"
 TropicalNumbers = "0.2.3"
-VectorizationBase = "0.19.12"
+VectorizationBase = "0.20"
 julia = "1"
 
 [extras]

--- a/src/fallbacks.jl
+++ b/src/fallbacks.jl
@@ -23,10 +23,14 @@ function naive_mul!(o::AbstractMatrix{T0}, a::AbstractMatrix{T1}, b::AbstractMat
 end
 
 # Overwrite the `mul!` in LinearAlgebra (also changes the behavior of `*` in Base)!
-@inline function LinearAlgebra.mul!(o::AbstractMatrix{T}, a::AbstractMatrix{T}, b::AbstractMatrix{T}, α::Number, β::Number) where T<:TropicalTypes
-    α = _convert_to_tropical(T, α)
-    β = _convert_to_tropical(T, β)
-    naive_mul!(o, a, b, α, β)
+for TA in [:(AbstractMatrix{T} where T<:TropicalTypes), :(Transpose{T,S} where {T<:TropicalTypes,S<:AbstractVecOrMat{T}})]
+    for TB in [:(AbstractMatrix{T} where T<:TropicalTypes), :(Transpose{T,S} where {T<:TropicalTypes,S<:AbstractVecOrMat{T}})]
+        @eval @inline function LinearAlgebra.mul!(o::AbstractMatrix{TO}, a::$TA, b::$TB, α::Number, β::Number) where TO
+            α = _convert_to_tropical(TO, α)
+            β = _convert_to_tropical(TO, β)
+            naive_mul!(o, a, b, α, β)
+        end
+    end
 end
 
 _convert_to_tropical(::Type{T}, α::TropicalTypes) where T<:TropicalTypes = α

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -75,6 +75,11 @@ end
     Tropical(res)
 end
 
+@inline function VectorizationBase._vload(ptr::AbstractStridedPointer{Tropical{T}}, u::Unroll, m::AbstractMask, ::A, ::StaticInt{RS}) where {T,A<:StaticBool,RS}
+    res = VectorizationBase._vload(notropical(ptr), u, m, A(), StaticInt{RS}())
+    Tropical(res)
+end
+
 @generated function VectorizationBase.zero_vecunroll(::StaticInt{N}, ::StaticInt{W}, ::Type{Tropical{T}}, ::StaticInt{RS}) where {N,W,T,RS}
     quote
         $(Expr(:meta,:inline))


### PR DESCRIPTION
@chriselrod I update the dependencies. However, there are some strange errors when computing
```julia
matmul(::Transpose{TropicalF32, ...}, ::Matrix{TropicalF32})
```

The error message is:
```
matmul: Error During Test at /home/leo/.julia/dev/TropicalGEMM/test/gemm.jl:18
  Test threw exception
  Expression: isapprox(distance(f(a, b), naive_mul!(similar(a), a, b)), 0; atol = atol)
  KeyError: key TropicalF32 not found
  Stacktrace:
    [1] getindex
      @ ./iddict.jl:93 [inlined]
    [2] shuffle_load_quote(#unused#::Type{TropicalF32}, integer_params::NTuple{9, Int64}, #unused#::Type{StaticInt{0}}, align::Bool, rs::Int64, MASKFLAG::UInt64)
      @ VectorizationBase ~/.julia/packages/VectorizationBase/FKaMR/src/vecunroll/memory.jl:89
    [3] #s157#317
      @ ~/.julia/packages/VectorizationBase/FKaMR/src/vecunroll/memory.jl:374 [inlined]
    [4] var"#s157#317"(A::Any, AU::Any, F::Any, N::Any, AV::Any, W::Any, M::Any, I::Any, T::Any, D::Any, RS::Any, UX::Any, X::Any, C::Any, B::Any, ::Any, sptr::Any, u::Any, sm::Any, #unused#::Type, #unused#::Type, #unused#::Any)
      @ VectorizationBase ./none:0
    [5] (::Core.GeneratedFunctionStub)(::Any, ::Vararg{Any, N} where N)
      @ Core ./boot.jl:571
    [6] _vload
      @ ~/.julia/packages/VectorizationBase/FKaMR/src/vecunroll/memory.jl:419 [inlined]
    [7] macro expansion
      @ ~/.julia/packages/LoopVectorization/VCKTK/src/reconstruct_loopset.jl:683 [inlined]
    [8] _avx_!(::Val{(false, 0, 0, false, 8, 32, 15, 64, 32768, 262144, 12582912, 0x0000000000000001)}, ::Val{(:numericconstant, Symbol("###zero###11###"), LoopVectorization.OperationStruct(0x0000000000000012, 0x0000000000000000, 0x0000000000000003,  ... ::Int64, ::Ptr{TropicalF32}, ::Ptr{TropicalF32}, ::Ptr{TropicalF32}, ::Int64, ::Int64, ::Int64)
      @ LoopVectorization ~/.julia/packages/LoopVectorization/VCKTK/src/reconstruct_loopset.jl:683
    [9] loopmul!
      @ ~/.julia/dev/Octavian/src/macrokernels.jl:83 [inlined]
   [10] _matmul!
      @ ~/.julia/dev/Octavian/src/matmul.jl:273 [inlined]
   [11] matmul(A::LinearAlgebra.Transpose{TropicalF32, Matrix{TropicalF32}}, B::Matrix{TropicalF32})
      @ Octavian ~/.julia/dev/Octavian/src/matmul.jl:209
   [12] macro expansion
      @ ~/.julia/dev/TropicalGEMM/test/gemm.jl:54 [inlined]
   [13] macro expansion
      @ /buildworker/worker/package_linux64/build/usr/share/julia/stdlib/v1.6/Test/src/Test.jl:1151 [inlined]
   [14] top-level scope
      @ ~/.julia/dev/TropicalGEMM/test/gemm.jl:39
```

I do not have any specialization for Float32 types. Do you have any clue on this error?