### PR TITLE
upgrade VectorizationBase

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
           - '1.6'
           - 'nightly'
         os:
-          - ubuntu-latest
+          - macos-latest
         arch:
           - x64
     steps:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,5 @@ jobs:
             ${{ runner.os }}-
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v1
         with:
-          file: lcov.info
+          coverage: false

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -13,7 +13,7 @@ jobs:
           - '1.6'
           - 'nightly'
         os:
-          - macos-latest
+          - ubuntu-latest
         arch:
           - x64
     steps:

--- a/Project.toml
+++ b/Project.toml
@@ -14,7 +14,7 @@ VectorizationBase = "3d5dd08c-fd9d-11e8-17fa-ed2836048c2f"
 LoopVectorization = "0.12.4"
 Octavian = "0.2.18, 0.3"
 TropicalNumbers = "0.2.3, 0.3, 0.4, 0.5"
-VectorizationBase = "0.20.10"
+VectorizationBase = "0.21"
 julia = "1.6"
 
 [extras]

--- a/src/gemm.jl
+++ b/src/gemm.jl
@@ -52,7 +52,7 @@ end
 end
 
 @inline function notropical(ptr::VectorizationBase.StridedPointer{Tropical{T},N,C,B,R,X,O}) where {T,N,C,B,R,X,O}
-    VectorizationBase.StridedPointer{T,N,C,B,R,X,O}(Ptr{T}(ptr.p), ptr.si)
+    stridedpointer(Ptr{T}(ptr.p), ptr.si, StaticInt{B}())
 end
 
 @inline function notropical(ptr::OffsetPrecalc{<:Tropical})


### PR DESCRIPTION
@chriselrod I am trying to upgrade VectorizationBase to v0.21. In order to see the place that it errors, I removed several lines about `stridedpointer` first. It magically not show any error.

Can you please help me check whether I am doing it correctly?